### PR TITLE
fix drawMask() image overflow

### DIFF
--- a/body-pix/src/output_rendering_util.ts
+++ b/body-pix/src/output_rendering_util.ts
@@ -363,7 +363,7 @@ export function drawMask(
     flipCanvasHorizontal(canvas);
   }
 
-  ctx.drawImage(image, 0, 0);
+  ctx.drawImage(image, 0, 0, width, height);
 
   ctx.globalAlpha = maskOpacity;
   if (maskImage) {


### PR DESCRIPTION
Image overflow was occurring on resized images while masks fit the canvas:
![1](https://user-images.githubusercontent.com/36408588/91844957-064e5080-ec61-11ea-9256-27eef6e3f0e5.PNG)

After fix:
![2](https://user-images.githubusercontent.com/36408588/91845096-431a4780-ec61-11ea-8418-a9f0b5b665ac.PNG)

